### PR TITLE
Bump node-streams to v9.0.0

### DIFF
--- a/packages.dhall
+++ b/packages.dhall
@@ -3,3 +3,4 @@ let upstream =
         sha256:292a92e32db0272db2089f3234140287c9eaf2fc15b6790a3c51f41471050eeb
 
 in  upstream
+      with node-streams.version = "v9.0.0"

--- a/spago.yaml
+++ b/spago.yaml
@@ -5,7 +5,7 @@ package:
     - either: ">=6.1.0 <7.0.0"
     - functions: ">=6.0.0 <7.0.0"
     - node-buffer: ">=8.0.0 <9.0.0"
-    - node-streams: ">=7.0.0 <8.0.0"
+    - node-streams: ">=9.0.0 <10.0.0"
     - prelude: ">=6.0.1 <7.0.0"
     - unsafe-coerce: ">=6.0.0 <7.0.0"
   name: node-zlib


### PR DESCRIPTION
Fixes FFI issues in `node-streams`